### PR TITLE
feat(mongodb): Add mongodb db and collection plugin config

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,121 +113,131 @@ module.exports = function (app) {
     plugin.name = 'SignalK to MongoDB URI';
     plugin.description = 'Signalk plugin to send data to any mongoDB URI';
     plugin.schema = {
-      "type": "object",
-      "description": "This plugin sends data to a MongoDB database",
-      "properties": {
-          "dbUri": {
-              "type": "string",
-              "title": "MongoDB URI",
-              "description": "The URI to connect to your MongoDB instance"
-          },
-          "batchSize": {
-              "type": "number",
-              "title": "Batch Size",
-              "description": "Number of values to send in a single batch to the MongoDB endpoint",
-              "default": 100
-          },
-          "flushSecs": {
-              "type": "number",
-              "title": "Flush Interval",
-              "description": "Maximum time in seconds to keep points in an unflushed batch, 0 means don't periodically flush",
-              "default": 60
-          },
-          "maxBuffer": {
-              "type": "number",
-              "title": "Maximum Buffer Size",
-              "description": "Maximum size of the buffer - it contains items that could not be sent for the first time",
-              "default": 1000
-          },
-          "ttlSecs": {
-              "type": "number",
-              "title": "Maximum Time to Live",
-              "description": "Maximum time to buffer data in seconds - older data is automatically removed from the buffer",
-              "default": 180
-          },
-          "tagAsSelf": {
-              "type": "boolean",
-              "title": "Tag as 'self' if applicable",
-              "description": "Tag measurements as {self: true} when from vessel.self - requires an MMSI or UUID to be set in the Vessel Base Data on the Server->Settings page",
-              "default": true
-          },
-          "defaultTags": {
-              "type": "array",
-              "title": "Default Tags",
-              "description": "Default tags added to every measurement",
-              "default": [],
-              "items": {
-                  "type": "object",
-                  "required": ["name", "value"],
-                  "properties": {
-                      "name": {
-                          "type": "string",
-                          "title": "Tag Name"
-                      },
-                      "value": {
-                          "type": "string",
-                          "title": "Tag Value"
-                      }
-                  }
-              }
-          },
-          "pathArray": {
-              "type": "array",
-              "title": "Paths",
-              "default": [],
-              "items": {
-                  "type": "object",
-                  "required": ["context", "path", "interval"],
-                  "properties": {
-                      "enabled": {
-                          "type": "boolean",
-                          "title": "Enabled?",
-                          "description": "Enable writes to MongoDB for this path (server restart is required)",
-                          "default": true
-                      },
-                      "context": {
-                          "type": "string",
-                          "title": "SignalK context",
-                          "description": "Context to record e.g. 'self' for own ship, or 'vessels.*' for all vessels, or '*' for everything",
-                          "default": "self"
-                      },
-                      "path": {
-                          "type": "string",
-                          "title": "SignalK path",
-                          "description": "Path to record e.g. 'navigation.position' for positions, or 'navigation.*' for all navigation data, or '*' for everything"
-                      },
-                      "interval": {
-                          "type": "number",
-                          "description": "Minimum milliseconds between data records",
-                          "title": "Recording interval",
-                          "default": 1000
-                      },
-                      "pathTags": {
-                          "title": "Path tags",
-                          "type": "array",
-                          "description": "Define any tags to include for this path",
-                          "default": [],
-                          "items": {
-                              "type": "object",
-                              "required": ["name", "value"],
-                              "properties": {
-                                  "name": {
-                                      "type": "string",
-                                      "title": "Tag Name"
-                                  },
-                                  "value": {
-                                      "type": "string",
-                                      "title": "Tag Value"
-                                  }
-                              }
-                          }
-                      }
-                  }
-              }
-          }
-      }
-  };
-  
+        "type": "object",
+        "properties": {
+            "dbUri": {
+                "type": "string",
+                "title": "MongoDB URI",
+                "description": "The URI to connect to your MongoDB instance"
+            },
+            "database": {
+                "type": "string",
+                "title": "Database Name",
+                "description": "The name of the MongoDB database to use"
+            },
+            "collection": {
+                "type": "string",
+                "title": "Collection Name",
+                "description": "The name of the MongoDB collection to use"
+            },
+            "batchSize": {
+                "type": "number",
+                "title": "Batch Size",
+                "default": 100,
+                "description": "Number of values to send in a single batch to the MongoDB endpoint"
+            },
+            "flushSecs": {
+                "type": "number",
+                "title": "Flush Interval",
+                "default": 60,
+                "description": "Maximum time in seconds to keep points in an unflushed batch, 0 means don't periodically flush"
+            },
+            "maxBuffer": {
+                "type": "number",
+                "title": "Maximum Buffer Size",
+                "default": 1000,
+                "description": "Maximum size of the buffer - it contains items that could not be sent for the first time"
+            },
+            "ttlSecs": {
+                "type": "number",
+                "title": "Maximum Time to Live",
+                "default": 180,
+                "description": "Maximum time to buffer data in seconds - older data is automatically removed from the buffer"
+            },
+            "tagAsSelf": {
+                "type": "boolean",
+                "title": "Tag as 'self' if applicable",
+                "default": true,
+                "description": "Tag measurements as {self: true} when from vessel.self - requires an MMSI or UUID to be set in the Vessel Base Data on the Server->Settings page"
+            },
+            "defaultTags": {
+                "type": "array",
+                "title": "Default Tags",
+                "default": [],
+                "description": "Default tags added to every measurement",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "title": "Tag Name"
+                        },
+                        "value": {
+                            "type": "string",
+                            "title": "Tag Value"
+                        }
+                    },
+                    "required": ["name", "value"]
+                }
+            },
+            "pathArray": {
+                "type": "array",
+                "title": "Paths",
+                "default": [],
+                "description": "Configure paths for data recording",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "title": "Enabled",
+                            "default": true,
+                            "description": "Enable writes to MongoDB for this path"
+                        },
+                        "context": {
+                            "type": "string",
+                            "title": "SignalK context",
+                            "description": "Context to record, e.g., 'self' for own ship, 'vessels.*' for all vessels"
+                        },
+                        "path": {
+                            "type": "string",
+                            "title": "SignalK path",
+                            "description": "Path to record, e.g., 'navigation.position'"
+                        },
+                        "interval": {
+                            "type": "number",
+                            "title": "Recording interval",
+                            "default": 1000,
+                            "description": "Minimum milliseconds between data records"
+                        },
+                        "pathTags": {
+                            "type": "array",
+                            "title": "Path Tags",
+                            "default": [],
+                            "description": "Define any tags to include for this path",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "title": "Tag Name"
+                                    },
+                                    "value": {
+                                        "type": "string",
+                                        "title": "Tag Value"
+                                    }
+                                },
+                                "required": ["name", "value"]
+                            }
+                        }
+                    },
+                    "required": ["context", "path", "interval"]
+                }
+            }
+        },
+        "required": ["dbUri", "database", "collection"]
+      };
+      
   
 
     return plugin;

--- a/mongodb.js
+++ b/mongodb.js
@@ -19,10 +19,14 @@ class MongoDb {
     isConnected = false; // Track connection status
 
     dbClient = null; // MongoDB client
+    database = null; // Database name
+    collection = null; // Collection name
 
-    constructor(app, dbUri) {
+    constructor(app, dbUri, database, collection) {
         this.app = app;
         this.dbUri = dbUri;
+        this.database = database;
+        this.collection = collection;
         this.dbClient = new MongoClient(dbUri);
     }
 
@@ -47,7 +51,7 @@ class MongoDb {
     }
 
     async start(options) {
-        this.app.debug(`mongodb options: ${JSON.stringify(options)}`);
+        this.app.debug(`MongoDB options: ${JSON.stringify(options)}`);
         this.options = options;
         await this.connect(); // Ensure connection before proceeding
         this.ttlMillis = options.ttlSecs ? options.ttlSecs * 1000 : this.ttlMillis;
@@ -140,8 +144,8 @@ class MongoDb {
                 batch.push(point);
             }
             if (batch.length > 0) {
-                const db = this.dbClient.db('prod'); // TODO: Add database name as plugin param
-                const collection = db.collection('nmea_signalk_data'); // TODO: Add collection name as plugin param
+                const db = this.dbClient.db(this.database); // Use configured database
+                const collection = db.collection(this.collection); // Use configured collection
                 await collection.insertMany(batch);
                 batch.forEach(point => this.buffer.delete(point.uid));
                 this.app.debug(`Inserted ${batch.length} documents into MongoDB`);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "signalk-to-mongodb",
-  "version": "1.1.0",
-  "description": "Signalk plugin to post data to mongodb uri",
+  "version": "2.0.0",
+  "description": "Signalk plugin to store data to cloud hosted mongodb uri",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
## Description
Users have the need to be able to choose the db and collection name. Add fields to the plugin to allow users to supply db and collection names.

## Acceptance Criteria
- [x] Mongo DB name is in plugin schema and is required
- [x] Mongo collection name is in plugin schema and is required
- [x] Plugin post data to supplied plugin args db and collection 