### PR TITLE
Replace unsafe usage of this with named reference

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ module.exports = function (app) {
             context: delta.context,
             path: val.path,
             time: new Date(update.timestamp), // Ensure time is stored as Date
-            uid: this.generateUID(JSON.stringify(val)), // Generate UID from the value
+            uid: mongodb.generateUID(JSON.stringify(val)), // Generate UID from the value
           };
 
           // Determine the type of value and handle accordingly


### PR DESCRIPTION
I changed the usage of `this` to an explicit reference to `mongodb` which resolves the scope issue I reported in #14 on my system.

Tested this using node v23.9.0 and signalk-server version 2.13.2.

## Description

Fixes #14 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
